### PR TITLE
MAINT: install scikit-learn and not sklearn

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,5 +45,5 @@ if __name__ == '__main__':
           platforms='any',
           packages=['dirty_cat'],
           package_data={'dirty_cat': ['VERSION.txt', 'data/*.csv.gz']},
-          install_requires=['sklearn', 'numpy', 'scipy', 'requests'],
+          install_requires=['scikit-learn', 'numpy', 'scipy', 'requests'],
           **extra_setuptools_args)


### PR DESCRIPTION
pip installing will install the alias sklearn from pip and not scikit-learn